### PR TITLE
Catch FailedLookupException during app startup

### DIFF
--- a/lib/src/app_startup.dart
+++ b/lib/src/app_startup.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -37,10 +38,15 @@ class AppStartupNotifier extends _$AppStartupNotifier {
       final jsonData = jsonDecode(jsonString);
       await db.loadOrUpdateFromTemplate(jsonData);
     } else {
-      // * Subsequent loads: sync with JSON data from the network
-      final jsonString = await ref.watch(fetchJsonTemplateProvider.future);
-      final jsonData = jsonDecode(jsonString);
-      await db.loadOrUpdateFromTemplate(jsonData);
+      try {
+        // * Subsequent loads: sync with JSON data from the network
+        final jsonString = await ref.watch(fetchJsonTemplateProvider.future);
+        final jsonData = jsonDecode(jsonString);
+        await db.loadOrUpdateFromTemplate(jsonData);
+      } on FailedLookupException catch (e) {
+        // TODO: Add error monitoring
+        log(e.message);
+      }
     }
   }
 


### PR DESCRIPTION
Prior to this fix, starting the app in offline mode would result in this error:

<img width="474" alt="Xnapper-2024-07-17-10 44 05" src="https://github.com/user-attachments/assets/59c6c22b-249a-411f-ac65-34777a0c0eb5">

Following the fix, the app continues to work even when started in offline mode (since the JSON from the app bundle can be used as a fallback).