### PR TITLE
Better error handling app startup

### DIFF
--- a/lib/src/app_startup.dart
+++ b/lib/src/app_startup.dart
@@ -44,8 +44,14 @@ class AppStartupNotifier extends _$AppStartupNotifier {
       final jsonData = jsonDecode(jsonString);
       await db.loadOrUpdateFromTemplate(jsonData);
     } catch (e) {
+      if (e is FailedLookupException) {
+        // * Fail silently as the app handles offline mode gracefully
+        return;
+      }
       // TODO: Add error monitoring
       log(e.toString());
+      // * Rethrow so we can show an error in the UI if something goes wrong
+      rethrow;
     }
   }
 

--- a/lib/src/app_startup.dart
+++ b/lib/src/app_startup.dart
@@ -30,23 +30,22 @@ class AppStartupNotifier extends _$AppStartupNotifier {
   }
 
   Future<void> _updateDatabaseFromJsonTemplate() async {
-    final db = ref.watch(appDatabaseProvider);
-    if (await db.isEpicsTableEmpty()) {
-      // * First time load: sync with JSON data from the local root bundle
-      final jsonString = await rootBundle
-          .loadString('assets/common/app_release_template.json');
+    try {
+      final String jsonString;
+      final db = ref.watch(appDatabaseProvider);
+      if (await db.isEpicsTableEmpty()) {
+        // * First time load: sync with JSON data from the local root bundle
+        jsonString = await rootBundle
+            .loadString('assets/common/app_release_template.json');
+      } else {
+        // * Subsequent loads: sync with JSON data from the network
+        jsonString = await ref.watch(gistClientProvider).fetchJsonTemplate();
+      }
       final jsonData = jsonDecode(jsonString);
       await db.loadOrUpdateFromTemplate(jsonData);
-    } else {
-      try {
-        // * Subsequent loads: sync with JSON data from the network
-        final jsonString = await ref.watch(fetchJsonTemplateProvider.future);
-        final jsonData = jsonDecode(jsonString);
-        await db.loadOrUpdateFromTemplate(jsonData);
-      } on FailedLookupException catch (e) {
-        // TODO: Add error monitoring
-        log(e.message);
-      }
+    } catch (e) {
+      // TODO: Add error monitoring
+      log(e.toString());
     }
   }
 

--- a/lib/src/app_startup.g.dart
+++ b/lib/src/app_startup.g.dart
@@ -7,7 +7,7 @@ part of 'app_startup.dart';
 // **************************************************************************
 
 String _$appStartupNotifierHash() =>
-    r'f89821d71ab3bf461f45213f64f3de801cddac73';
+    r'fcc5b11beda1bca9aa0deacb903ab206917bd2d7';
 
 /// App startup provider and widget (below)
 /// For more info, read: https://codewithandrea.com/articles/robust-app-initialization-riverpod/

--- a/lib/src/data/gist_client.dart
+++ b/lib/src/data/gist_client.dart
@@ -47,11 +47,6 @@ GistClient gistClient(GistClientRef ref) {
   return GistClient(dio: dio);
 }
 
-@riverpod
-Future<String> fetchJsonTemplate(FetchJsonTemplateRef ref) {
-  return ref.watch(gistClientProvider).fetchJsonTemplate();
-}
-
 /// Exceptions supported by the GistClient
 sealed class APIException implements Exception {
   String get message;

--- a/lib/src/data/gist_client.g.dart
+++ b/lib/src/data/gist_client.g.dart
@@ -20,20 +20,5 @@ final gistClientProvider = AutoDisposeProvider<GistClient>.internal(
 );
 
 typedef GistClientRef = AutoDisposeProviderRef<GistClient>;
-String _$fetchJsonTemplateHash() => r'c41496a56b14bfffaf97ded62e02225d625c466e';
-
-/// See also [fetchJsonTemplate].
-@ProviderFor(fetchJsonTemplate)
-final fetchJsonTemplateProvider = AutoDisposeFutureProvider<String>.internal(
-  fetchJsonTemplate,
-  name: r'fetchJsonTemplateProvider',
-  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
-      ? null
-      : _$fetchJsonTemplateHash,
-  dependencies: null,
-  allTransitiveDependencies: null,
-);
-
-typedef FetchJsonTemplateRef = AutoDisposeFutureProviderRef<String>;
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member


### PR DESCRIPTION
Follow up from #5.

Updated the logic in the catch block to fail silently on `FailedLookupException`, rethrow otherwise:

```dart
  Future<void> _updateDatabaseFromJsonTemplate() async {
    try {
      final String jsonString;
      final db = ref.watch(appDatabaseProvider);
      if (await db.isEpicsTableEmpty()) {
        // * First time load: sync with JSON data from the local root bundle
        jsonString = await rootBundle
            .loadString('assets/common/app_release_template.json');
      } else {
        // * Subsequent loads: sync with JSON data from the network
        jsonString = await ref.watch(gistClientProvider).fetchJsonTemplate();
      }
      final jsonData = jsonDecode(jsonString);
      await db.loadOrUpdateFromTemplate(jsonData);
    } catch (e) {
      if (e is FailedLookupException) {
        // * Fail silently as the app handles offline mode gracefully
        return;
      }
      // TODO: Add error monitoring
      log(e.toString());
      // * Rethrow so we can show an error in the UI if something goes wrong
      rethrow;
    }
  }
```

This ensures any DB or HTTP errors are still thrown and can be handled by the calling code.